### PR TITLE
Makefile: Fix version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ PROJECT_NAME			:= safelinks
 
 # What package holds the "version" variable used in branding/version output?
 # VERSION_VAR_PKG			= $(shell go list -m)
-VERSION_VAR_PKG			:= $(shell go list -m)/internal/config
-# VERSION_VAR_PKG			= main
+# VERSION_VAR_PKG			:= $(shell go list -m)/internal/config
+VERSION_VAR_PKG			= main
 
 OUTPUTDIR 				:= release_assets
 


### PR DESCRIPTION
As an unintentional effect of recent bulk refactoring work, the Makefile for this project "absorbed" incompatible changes common to other projects that I maintain.

We resolve the issue by resetting the target of linker flag modifications to the correct package containing the `version` variable.

fixes GH-77