### PR TITLE
Add support for processing multiple input lines

### DIFF
--- a/cmd/usl/config.go
+++ b/cmd/usl/config.go
@@ -26,9 +26,10 @@ const (
 
 // Config represents configuration details for this application.
 type Config struct {
-	URL     string
-	Verbose bool
-	Version bool
+	URL      string
+	Filename string
+	Verbose  bool
+	Version  bool
 }
 
 // NewConfig processes flag values and returns an application configuration.
@@ -56,6 +57,8 @@ func usage() {
 func setupFlags(c *Config) {
 	flag.StringVar(&c.URL, "url", "", "Safe Links URL to decode")
 	flag.StringVar(&c.URL, "u", "", "Safe Links URL to decode"+" (shorthand)")
+	flag.StringVar(&c.Filename, "inputfile", "", "Path to file containing Safe Links URLs to decode")
+	flag.StringVar(&c.Filename, "f", "", "Path to file containing Safe Links URL to decode"+" (shorthand)")
 	flag.BoolVar(&c.Verbose, "verbose", false, "Display additional information about a given Safe Links URL")
 	flag.BoolVar(&c.Verbose, "v", false, "Display additional information about a given Safe Links URL"+" (shorthand)")
 	flag.BoolVar(&c.Version, "version", false, "Display version information and immediately exit")

--- a/cmd/usl/output.go
+++ b/cmd/usl/output.go
@@ -20,7 +20,7 @@ func simpleOutput(u *url.URL, w io.Writer) {
 	urlValues := u.Query()
 	maskedURL := urlValues.Get("url")
 
-	fmt.Fprintf(w, "\nOriginal URL:\n\n%v\n", maskedURL)
+	fmt.Fprintln(w, maskedURL)
 }
 
 // verboseOutput handles generating extended or "verbose" output when


### PR DESCRIPTION
- add support for reading input URLs from a file
- add support for reading input URLs from stdin
- retain interactive prompt if no input given
- remove leading explanation text from results
- emit URL parsing failure text to stderr, continue processing URLs
  - allow for batch operation
  - allow for splitting success results and error output across different files

refs GH-78