### PR TITLE
Update flag help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ binaries.
 | `version`        | No       | `false` | No     | `version`            | Whether to display application version and then immediately exit application. |
 | `v`, `verbose`   | No       | `false` | No     | `v`, `verbose`       | Display additional information about a given Safe Links URL.                  |
 | `u`, `url`       | *maybe*  |         | No     | `u`, `url`           | Safe Links URL to decode                                                      |
-| `f`, `inputfile` | *maybe*  |         | No     | *valid path to file* | Path to file containing Safe Links URL to decode                              |
+| `f`, `inputfile` | *maybe*  |         | No     | *valid path to file* | Path to file containing Safe Links URLs to decode                             |
 
 NOTE: If an input `url` is not specified (e.g., via flag, positional argument
 or standard input) a prompt is provided to enter a Safe Links URL.

--- a/cmd/usl/config.go
+++ b/cmd/usl/config.go
@@ -62,7 +62,7 @@ func setupFlags(c *Config) {
 	flag.StringVar(&c.URL, "url", "", "Safe Links URL to decode")
 	flag.StringVar(&c.URL, "u", "", "Safe Links URL to decode"+shorthandFlagSuffix)
 	flag.StringVar(&c.Filename, "inputfile", "", "Path to file containing Safe Links URLs to decode")
-	flag.StringVar(&c.Filename, "f", "", "Path to file containing Safe Links URL to decode"+shorthandFlagSuffix)
+	flag.StringVar(&c.Filename, "f", "", "Path to file containing Safe Links URLs to decode"+shorthandFlagSuffix)
 	flag.BoolVar(&c.Verbose, "verbose", false, "Display additional information about a given Safe Links URL")
 	flag.BoolVar(&c.Verbose, "v", false, "Display additional information about a given Safe Links URL"+shorthandFlagSuffix)
 	flag.BoolVar(&c.Version, "version", false, "Display version information and immediately exit")


### PR DESCRIPTION
Correct text to properly indicate that multiple Safe Links URLs can be decoded from a specified input file.

Also, correct README flag description to match.