### PR TITLE
Fix project analysis workflow call

### DIFF
--- a/.github/workflows/project-analysis.yml
+++ b/.github/workflows/project-analysis.yml
@@ -21,8 +21,6 @@ jobs:
     # Only run this job on non-push events (e.g., pull requests)
     if: github.event_name != 'push'
     name: Lint
-    with:
-      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
     uses: atc0005/shared-project-resources/.github/workflows/lint-project-files.yml@master
 
   vulnerability:


### PR DESCRIPTION
The called lint-project-files.yml file does not accept (nor need) the os-dependencies list.

refs GH-225