### PR TITLE
Fix GetURLPatternsUsingIndex URL end pos matching

### DIFF
--- a/internal/safelinks/prototyping.go
+++ b/internal/safelinks/prototyping.go
@@ -128,17 +128,7 @@ func GetURLPatternsUsingIndex(input string) ([]FoundURLPattern, error) {
 			break
 		}
 
-		// Assume we found ending point until proven otherwise.
-		// urlEnd := next
-
-		// for _, char := range remaining[next:] {
-		// 	if unicode.IsSpace(char) {
-		// 		break // we found end of URL pattern
-		// 	}
-		// 	urlEnd++
-		// }
-
-		urlEnd := getURLIndexEndPosition(remaining[next:], next)
+		urlEnd := getURLIndexEndPosition(remaining, next)
 
 		urlPatterns = append(
 			urlPatterns,


### PR DESCRIPTION
Previous refactoring for 0b8ac0acec3c37831bb1f3e183c1fc2c9a1b91fd incorrectly passed the same slice into the helper function that it needed to initially calculate on its own.

However, since GetURLPatternsUsingIndex was not called by the `dsl` tool it was unaffected by this issue.

refs GH-210
refs GH-185