### PR TITLE
Disable internal/safelinks logging by default

### DIFF
--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -36,8 +36,12 @@ import (
 
 func main() {
 	userFeedbackOut := os.Stderr
-	// debugLoggingOut := os.Stderr // switch to os.Stderr for debugging
-	debugLoggingOut := io.Discard // use io.Discard for normal operation
+
+	// use io.Discard for normal operation
+	// switch to os.Stderr for debugging
+	debugLoggingOut := io.Discard
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	log.SetOutput(debugLoggingOut)
 
 	// We wrap the os.Exit() behavior so that we can safely use deferred

--- a/cmd/dslg/main.go
+++ b/cmd/dslg/main.go
@@ -18,8 +18,11 @@ import (
 )
 
 func main() {
-	debugLoggingOut := os.Stderr // switch to os.Stderr for debugging
-	// debugLoggingOut := io.Discard // use io.Discard for normal operation
+	// use io.Discard for normal operation
+	// switch to os.Stderr for debugging
+	debugLoggingOut := os.Stderr
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	log.SetOutput(debugLoggingOut)
 
 	a := app.New()

--- a/internal/safelinks/init.go
+++ b/internal/safelinks/init.go
@@ -1,0 +1,18 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/safelinks
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package safelinks
+
+import (
+	"io"
+	"log"
+)
+
+func init() {
+	// Disable logging out by default.
+	log.SetOutput(io.Discard)
+}


### PR DESCRIPTION
- discard logging output explicitly per internal/safelinks init func
- continue discarding debug logging for cmd/dsl
- continue emitting debug logging for cmd/dslg
  - the plan is to disable this logging also once cmd/dslg stabilizes