### PR TITLE
Update Dependabot build Dockerfile paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -157,7 +157,25 @@ updates:
       prefix: "Build image"
 
   - package-ecosystem: docker
-    directory: "/dependabot/docker/builds"
+    directory: "/dependabot/docker/builds/x86"
+    open-pull-requests-limit: 10
+    target-branch: "development"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "builds"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "Build image"
+
+  - package-ecosystem: docker
+    directory: "/dependabot/docker/builds/x64"
     open-pull-requests-limit: 10
     target-branch: "development"
     schedule:


### PR DESCRIPTION
The `development` branch has already been reworked to support separate build images for x86 and x64 architectures but the Dependabot monitoring for those paths were not updated when those path changes were merged to the primary branch.

This commit updates Dependabot monitoring to correctly cover both build Dockerfile paths.

refs GH-225