### PR TITLE
Disable potential auto EOL conversion for testdata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,11 @@
 
 dependabot/docker/builds/Dockerfile merge=ours
 dependabot/docker/go/Dockerfile merge=ours
+
+# Preserve existing line endings in testdata files; explicitly disable any
+# potential automatic end of line conversion due to client-specific
+# `core.autocrlf` or `core.eol` values.
+#
+# https://git-scm.com/docs/gitattributes#_checking_out_and_checking_in
+# https://stackoverflow.com/a/2825829
+testdata/ -text


### PR DESCRIPTION
Some of the upcoming testdata files will have intentional line endings set per file and we do not want git's automatic conversion feature to (potentially, based on client settings) interfere with explicitly chosen EOLs.

refs GH-251