### PR TITLE
Linting fixes for eslg, app description tweak

### DIFF
--- a/cmd/eslg/config.go
+++ b/cmd/eslg/config.go
@@ -20,17 +20,13 @@ var version = "x.y.z"
 const (
 	myAppName        string = "eslg"
 	myAppURL         string = "https://github.com/atc0005/safelinks"
-	myAppDescription string = "Go-based tooling to manipulate (e.g., normalize/decode) Microsoft Office 365 \"Safe Links\" URLs."
+	myAppDescription string = "GUI tool for encoding normal URLs within input text for testing purposes."
 )
 
 // GUI app constants.
 const (
 	windowSizeHeight float32 = 800
 	windowSizeWidth  float32 = 650
-)
-
-const (
-	safeLinksAboutURL string = "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/safe-links-about"
 )
 
 // Constants used for field and button text.

--- a/cmd/eslg/main.go
+++ b/cmd/eslg/main.go
@@ -26,7 +26,9 @@ func main() {
 	log.SetOutput(debugLoggingOut)
 
 	// Help this tool stand out from the dslg app.
-	os.Setenv("FYNE_THEME", "light")
+	if err := os.Setenv("FYNE_THEME", "light"); err != nil {
+		log.Println("Failed to set fyne toolkit theme")
+	}
 
 	// NOTE: This is deprecated and set to be removed in v3.0.
 	// fyne.CurrentApp().Settings().SetTheme(theme.LightTheme())


### PR DESCRIPTION
## Fixes

- gosec G404: Use of weak random number generator
  - attempt crypto/rand based PRNG sourced value first before falling back to math/rand sourced value
  - use nolint directives to ignore G404 linting rule
  - NOTE: this use case does not require a cryptographically strong pseudo-random number generator
- errcheck: os.Setenv call did not check error
  - we now emit a debug logging message if this attempt fails as the attempt is best effort, not a requirement
- unused: safeLinksAboutURL
  - just remove it as it is not needed for this tool

## Other

- update app description to be more specific to this tool
  - will probably apply similar change to dslg tool also