### PR TITLE
Remove stray placeholder from eslg about text

### DIFF
--- a/cmd/eslg/buttons.go
+++ b/cmd/eslg/buttons.go
@@ -95,7 +95,7 @@ func newResetButton(w fyne.Window, inputField *widget.Entry, copyButton *widget.
 func newAboutButton(_ fyne.Window, inputField *widget.Entry, copyButton *widget.Button, errOutField *widget.Entry, outputField *widget.Label) *widget.Button {
 	aboutButton := widget.NewButton("About", func() {
 		log.Println("Displaying About text")
-		inputField.PlaceHolder = "Description:\n\n%s\n\n" +
+		inputField.PlaceHolder = "Description:\n\n" +
 			"GUI tool used to create faux Safe Links encoded URLs for testing purposes"
 
 		inputField.Text = ""


### PR DESCRIPTION
This was left behind from earlier copy/paste/modify work using the dslg tool as a starting point.