### PR TITLE
Require expected safelinks domain

### DIFF
--- a/internal/safelinks/safelinks.go
+++ b/internal/safelinks/safelinks.go
@@ -63,8 +63,14 @@ func ValidURL(input string) bool {
 
 // ValidSafeLinkURL validates whether a given url.URL is a valid Safe Links
 // URL.
-func ValidSafeLinkURL(input *url.URL) bool {
-	if err := assertValidURLParameter(input); err != nil {
+func ValidSafeLinkURL(u *url.URL) bool {
+	if !strings.Contains(u.Host, SafeLinksBaseDomain) {
+		log.Printf("FAIL: URL %q fails base domain check", u.String())
+		return false
+	}
+
+	if err := assertValidURLParameter(u); err != nil {
+		log.Printf("FAIL: URL %q fails %q parameter check", u.String(), "url")
 		return false
 	}
 


### PR DESCRIPTION
Update safelinks.ValidSafeLinkURL helper func to require that the safelinks.protection.outlook.com "base domain" is present in all URLs to be considered an encoded Safe Links URL.