### PR TITLE
Add new testdata URLs with a `url` parameter

### DIFF
--- a/internal/safelinks/exported_test.go
+++ b/internal/safelinks/exported_test.go
@@ -230,11 +230,11 @@ func TestURLsFindsAllValidURLs(t *testing.T) {
 	}{
 		"Encoded list of URLs with LF EOL": {
 			input:          inputEncodedAllListOfURLsWithLFEol,
-			foundURLsCount: 15,
+			foundURLsCount: 17,
 		},
 		"Encoded list of URLs with CRLF EOL": {
 			input:          inputEncodedAllListOfURLsWithCRLFEol,
-			foundURLsCount: 15,
+			foundURLsCount: 17,
 		},
 		"Encoded single URL with LF EOL": {
 			input:          inputEncodedSingleSafelinksURLWithLFEol,
@@ -246,53 +246,53 @@ func TestURLsFindsAllValidURLs(t *testing.T) {
 		},
 		"Encoded email with angle brackets with CRLF EOL": {
 			input:          inputEncodedAllEmailWithAngleBracketsWithCRLFEol,
-			foundURLsCount: 5,
+			foundURLsCount: 7,
 		},
 		"Encoded email with angle brackets with LF EOL": {
 			input:          inputEncodedAllEmailWithAngleBracketsWithLFEol,
-			foundURLsCount: 5,
+			foundURLsCount: 7,
 		},
 		"Encoded email without angle brackets with CRLF EOL": {
 			input:          inputEncodedAllEmailWithoutAngleBracketsWithCRLFEol,
-			foundURLsCount: 5,
+			foundURLsCount: 7,
 		},
 		"Encoded email without angle brackets with LF EOL": {
 			input:          inputEncodedAllEmailWithoutAngleBracketsWithLFEol,
-			foundURLsCount: 5,
+			foundURLsCount: 7,
 		},
 
 		"Mixed encoded email with angle brackets with CRLF EOL": {
 			input:          inputEncodedMixedEmailWithAngleBracketsWithCRLFEol,
-			foundURLsCount: 5,
+			foundURLsCount: 7,
 		},
 		"Mixed encoded email with angle brackets with LF EOL": {
 			input:          inputEncodedMixedEmailWithAngleBracketsWithLFEol,
-			foundURLsCount: 5,
+			foundURLsCount: 7,
 		},
 		"Mixed encoded email without angle brackets with CRLF EOL": {
 			input:          inputEncodedMixedEmailWithoutAngleBracketsWithCRLFEol,
-			foundURLsCount: 5,
+			foundURLsCount: 7,
 		},
 		"Mixed encoded email without angle brackets with LF EOL": {
 			input:          inputEncodedMixedEmailWithoutAngleBracketsWithLFEol,
-			foundURLsCount: 5,
+			foundURLsCount: 7,
 		},
 		"Mixed encoded list of URLs with CRLF EOL": {
 			input:          inputEncodedMixedListOfURLsWithCRLFEol,
-			foundURLsCount: 15,
+			foundURLsCount: 17,
 		},
 		"Mixed encoded list of URLs with LF EOL": {
 			input:          inputEncodedMixedListOfURLsWithLFEol,
-			foundURLsCount: 15,
+			foundURLsCount: 17,
 		},
 
 		"Mixed invalid list of URLs with LF EOL": {
 			input:          inputInvalidMixedListOfURLsWithLFEol,
-			foundURLsCount: 7,
+			foundURLsCount: 9,
 		},
 		"Mixed invalid list of URLs with CRLF EOL": {
 			input:          inputInvalidMixedListOfURLsWithCRLFEol,
-			foundURLsCount: 7,
+			foundURLsCount: 9,
 		},
 		"Mixed invalid URLs email with angle brackets with CRLF EOL": {
 			input:          inputInvalidMixedEmailWithAngleBracketsWithCRLFEol,
@@ -411,62 +411,62 @@ func TestFilterURLsCorrectlyFiltersByType(t *testing.T) {
 		"Mixed encoded email with angle brackets with CRLF EOL": {
 			input:                      inputEncodedMixedEmailWithAngleBracketsWithCRLFEol,
 			foundEncodedLinksURLsCount: 2,
-			foundUnencodedURLsCount:    3,
+			foundUnencodedURLsCount:    5,
 		},
 		"Mixed encoded email with angle brackets with LF EOL": {
 			input:                      inputEncodedMixedEmailWithAngleBracketsWithLFEol,
 			foundEncodedLinksURLsCount: 2,
-			foundUnencodedURLsCount:    3,
+			foundUnencodedURLsCount:    5,
 		},
 		"Mixed encoded email without angle brackets with CRLF EOL": {
 			input:                      inputEncodedMixedEmailWithoutAngleBracketsWithCRLFEol,
 			foundEncodedLinksURLsCount: 2,
-			foundUnencodedURLsCount:    3,
+			foundUnencodedURLsCount:    5,
 		},
 		"Mixed encoded email without angle brackets with LF EOL": {
 			input:                      inputEncodedMixedEmailWithoutAngleBracketsWithLFEol,
 			foundEncodedLinksURLsCount: 2,
-			foundUnencodedURLsCount:    3,
+			foundUnencodedURLsCount:    5,
 		},
 		"Mixed encoded list of URLs with CRLF EOL": {
 			input:                      inputEncodedMixedListOfURLsWithCRLFEol,
 			foundEncodedLinksURLsCount: 8,
-			foundUnencodedURLsCount:    7,
+			foundUnencodedURLsCount:    9,
 		},
 		"Mixed encoded list of URLs with LF EOL": {
 			input:                      inputEncodedMixedListOfURLsWithLFEol,
 			foundEncodedLinksURLsCount: 8,
-			foundUnencodedURLsCount:    7,
+			foundUnencodedURLsCount:    9,
 		},
 
 		"Encoded email with angle brackets with CRLF EOL": {
 			input:                      inputEncodedAllEmailWithAngleBracketsWithCRLFEol,
-			foundEncodedLinksURLsCount: 5,
+			foundEncodedLinksURLsCount: 7,
 			foundUnencodedURLsCount:    0,
 		},
 		"Encoded email with angle brackets with LF EOL": {
 			input:                      inputEncodedAllEmailWithAngleBracketsWithLFEol,
-			foundEncodedLinksURLsCount: 5,
+			foundEncodedLinksURLsCount: 7,
 			foundUnencodedURLsCount:    0,
 		},
 		"Encoded email without angle brackets with CRLF EOL": {
 			input:                      inputEncodedAllEmailWithoutAngleBracketsWithCRLFEol,
-			foundEncodedLinksURLsCount: 5,
+			foundEncodedLinksURLsCount: 7,
 			foundUnencodedURLsCount:    0,
 		},
 		"Encoded email without angle brackets with LF EOL": {
 			input:                      inputEncodedAllEmailWithoutAngleBracketsWithLFEol,
-			foundEncodedLinksURLsCount: 5,
+			foundEncodedLinksURLsCount: 7,
 			foundUnencodedURLsCount:    0,
 		},
 		"Encoded list of URLs with CRLF EOL": {
 			input:                      inputEncodedAllListOfURLsWithCRLFEol,
-			foundEncodedLinksURLsCount: 15,
+			foundEncodedLinksURLsCount: 17,
 			foundUnencodedURLsCount:    0,
 		},
 		"Encoded list of URLs with LF EOL": {
 			input:                      inputEncodedAllListOfURLsWithLFEol,
-			foundEncodedLinksURLsCount: 15,
+			foundEncodedLinksURLsCount: 17,
 			foundUnencodedURLsCount:    0,
 		},
 		"Encoded single URL with CRLF EOL": {
@@ -483,12 +483,12 @@ func TestFilterURLsCorrectlyFiltersByType(t *testing.T) {
 		"Unencoded list of URLs with LF EOL": {
 			input:                      outputDecodedListOfURLsWithLFEol,
 			foundEncodedLinksURLsCount: 0,
-			foundUnencodedURLsCount:    15,
+			foundUnencodedURLsCount:    17,
 		},
 		"Unencoded list of URLs with CRLF EOL": {
 			input:                      outputDecodedListOfURLsWithCRLFEol,
 			foundEncodedLinksURLsCount: 0,
-			foundUnencodedURLsCount:    15,
+			foundUnencodedURLsCount:    17,
 		},
 		"Unencoded single URL with LF EOL": {
 			input:                      outputDecodedSingleURLWithLFEol,
@@ -503,22 +503,22 @@ func TestFilterURLsCorrectlyFiltersByType(t *testing.T) {
 		"Unencoded email with angle brackets with LF EOL": {
 			input:                      outputDecodedEmailWithAngleBracketsWithLFEol,
 			foundEncodedLinksURLsCount: 0,
-			foundUnencodedURLsCount:    5,
+			foundUnencodedURLsCount:    7,
 		},
 		"Unencoded email with angle brackets with CRLF EOL": {
 			input:                      outputDecodedEmailWithAngleBracketsWithCRLFEol,
 			foundEncodedLinksURLsCount: 0,
-			foundUnencodedURLsCount:    5,
+			foundUnencodedURLsCount:    7,
 		},
 		"Unencoded email without angle brackets with LF EOL": {
 			input:                      outputDecodedEmailWithoutAngleBracketsWithLFEol,
 			foundEncodedLinksURLsCount: 0,
-			foundUnencodedURLsCount:    5,
+			foundUnencodedURLsCount:    7,
 		},
 		"Unencoded email without angle brackets with CRLF EOL": {
 			input:                      outputDecodedEmailWithoutAngleBracketsWithCRLFEol,
 			foundEncodedLinksURLsCount: 0,
-			foundUnencodedURLsCount:    5,
+			foundUnencodedURLsCount:    7,
 		},
 	}
 
@@ -596,27 +596,27 @@ func TestSafeLinkURLsFindsAllValidSafeLinks(t *testing.T) {
 
 		"Encoded email with angle brackets with CRLF EOL": {
 			input:                 inputEncodedAllEmailWithAngleBracketsWithCRLFEol,
-			foundEncodedURLsCount: 5,
+			foundEncodedURLsCount: 7,
 		},
 		"Encoded email with angle brackets with LF EOL": {
 			input:                 inputEncodedAllEmailWithAngleBracketsWithLFEol,
-			foundEncodedURLsCount: 5,
+			foundEncodedURLsCount: 7,
 		},
 		"Encoded email without angle brackets with CRLF EOL": {
 			input:                 inputEncodedAllEmailWithoutAngleBracketsWithCRLFEol,
-			foundEncodedURLsCount: 5,
+			foundEncodedURLsCount: 7,
 		},
 		"Encoded email without angle brackets with LF EOL": {
 			input:                 inputEncodedAllEmailWithoutAngleBracketsWithLFEol,
-			foundEncodedURLsCount: 5,
+			foundEncodedURLsCount: 7,
 		},
 		"Encoded list of URLs with CRLF EOL": {
 			input:                 inputEncodedAllListOfURLsWithCRLFEol,
-			foundEncodedURLsCount: 15,
+			foundEncodedURLsCount: 17,
 		},
 		"Encoded list of URLs with LF EOL": {
 			input:                 inputEncodedAllListOfURLsWithLFEol,
-			foundEncodedURLsCount: 15,
+			foundEncodedURLsCount: 17,
 		},
 		"Encoded single URL with CRLF EOL": {
 			input:                 inputEncodedSingleSafelinksURLWithCRLFEol,

--- a/internal/safelinks/testdata/input/encoded-all/email-with-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-all/email-with-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts&data=data_placeholder&sdata=sdata_placeholder&reserved=0>
 <https://nam12.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public&data=data_placeholder&sdata=sdata_placeholder&reserved=0>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<https://eur04.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0>
+<https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/encoded-all/email-with-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-all/email-with-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts&data=data_placeholder&sdata=sdata_placeholder&reserved=0>
 <https://nam12.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public&data=data_placeholder&sdata=sdata_placeholder&reserved=0>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<https://eur04.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0>
+<https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/encoded-all/email-without-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-all/email-without-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ https://nam10.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.c
 https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://nam12.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+https://eur04.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0
+https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/encoded-all/email-without-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-all/email-without-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ https://nam10.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.c
 https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://nam12.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+https://eur04.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0
+https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/encoded-all/list-of-urls-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-all/list-of-urls-with-crlf-eol.txt
@@ -13,3 +13,5 @@ https://nam01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fleanpub.com%2F
 https://nam02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fleanpub.com%2Fdockerdeepdive&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780132629454&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://emea01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780134278315&data=data_placeholder&sdata=sdata_placeholder&reserved=0
+https://eur04.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0
+https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0

--- a/internal/safelinks/testdata/input/encoded-all/list-of-urls-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-all/list-of-urls-with-lf-eol.txt
@@ -13,3 +13,5 @@ https://nam01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fleanpub.com%2F
 https://nam02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fleanpub.com%2Fdockerdeepdive&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780132629454&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://emea01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780134278315&data=data_placeholder&sdata=sdata_placeholder&reserved=0
+https://eur04.safelinks.protection.outlook.com/?url=http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0
+https://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F&data=data_placeholder&sdata=sdata_placeholder&reserved=0

--- a/internal/safelinks/testdata/input/encoded-mixed/email-with-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-mixed/email-with-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https://docs.example.com/guides/blog/publishing-drafts>
 <https://docs.example.com/guides/blog/promoting-to-public>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F>
+<https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/encoded-mixed/email-with-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-mixed/email-with-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https://docs.example.com/guides/blog/publishing-drafts>
 <https://docs.example.com/guides/blog/promoting-to-public>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F>
+<https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/encoded-mixed/email-without-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-mixed/email-without-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ https://eur04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.c
 https://docs.example.com/guides/blog/publishing-drafts
 https://docs.example.com/guides/blog/promoting-to-public
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/encoded-mixed/email-without-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-mixed/email-without-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ https://eur04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.example.c
 https://docs.example.com/guides/blog/publishing-drafts
 https://docs.example.com/guides/blog/promoting-to-public
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/encoded-mixed/list-of-urls-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-mixed/list-of-urls-with-crlf-eol.txt
@@ -13,3 +13,5 @@ https://emea01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fleanpub.com%2
 https://eur04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fleanpub.com%2Fdockerdeepdive&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://nam10.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780132629454&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://www.informit.com/store/unix-and-linux-system-administration-handbook-9780134278315
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F

--- a/internal/safelinks/testdata/input/encoded-mixed/list-of-urls-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-mixed/list-of-urls-with-lf-eol.txt
@@ -13,3 +13,5 @@ https://emea01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fleanpub.com%2
 https://eur04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fleanpub.com%2Fdockerdeepdive&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://nam10.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780132629454&data=data_placeholder&sdata=sdata_placeholder&reserved=0
 https://www.informit.com/store/unix-and-linux-system-administration-handbook-9780134278315
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F

--- a/internal/safelinks/testdata/input/invalid-all/email-with-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-all/email-with-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts>
 <https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F>
+<https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/invalid-all/email-with-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-all/email-with-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts>
 <https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F>
+<https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/invalid-all/email-without-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-all/email-without-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fbest-practices
 https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts
 https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/invalid-all/email-without-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-all/email-without-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fbest-practices
 https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts
 https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/invalid-all/list-of-urls-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-all/list-of-urls-with-crlf-eol.txt
@@ -13,3 +13,5 @@ https%3A%2F%2Fleanpub.com%2Fthekubernetesbook
 https%3A%2F%2Fleanpub.com%2Fdockerdeepdive
 https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780132629454
 https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780134278315
+http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F

--- a/internal/safelinks/testdata/input/invalid-all/list-of-urls-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-all/list-of-urls-with-lf-eol.txt
@@ -13,3 +13,5 @@ https%3A%2F%2Fleanpub.com%2Fthekubernetesbook
 https%3A%2F%2Fleanpub.com%2Fdockerdeepdive
 https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780132629454
 https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780134278315
+http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F

--- a/internal/safelinks/testdata/input/invalid-mixed/email-with-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-mixed/email-with-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts>
 <https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F>
+<https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/invalid-mixed/email-with-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-mixed/email-with-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts>
 <https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F>
+<https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/invalid-mixed/email-without-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-mixed/email-without-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ https://docs.example.com/guides/blog/best-practices
 https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts
 https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/invalid-mixed/email-without-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-mixed/email-without-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ https://docs.example.com/guides/blog/best-practices
 https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpublishing-drafts
 https%3A%2F%2Fdocs.example.com%2Fguides%2Fblog%2Fpromoting-to-public
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+http%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+https%3A%2F%2Fwww.example.com%2Flinkchecker.php%3Furl%3Dhttps%253A%252F%252Fwww.google.com%252F
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/input/invalid-mixed/list-of-urls-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-mixed/list-of-urls-with-crlf-eol.txt
@@ -13,3 +13,5 @@ https://leanpub.com/thekubernetesbook
 https%3A%2F%2Fleanpub.com%2Fdockerdeepdive
 https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780132629454
 https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780134278315
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F

--- a/internal/safelinks/testdata/input/invalid-mixed/list-of-urls-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/invalid-mixed/list-of-urls-with-lf-eol.txt
@@ -13,3 +13,5 @@ https://leanpub.com/thekubernetesbook
 https%3A%2F%2Fleanpub.com%2Fdockerdeepdive
 https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780132629454
 https%3A%2F%2Fwww.informit.com%2Fstore%2Funix-and-linux-system-administration-handbook-9780134278315
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F

--- a/internal/safelinks/testdata/output/embedded/decoded-email-with-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/output/embedded/decoded-email-with-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https://docs.example.com/guides/blog/publishing-drafts>
 <https://docs.example.com/guides/blog/promoting-to-public>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F>
+<https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/output/embedded/decoded-email-with-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/output/embedded/decoded-email-with-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ process in depth:
 <https://docs.example.com/guides/blog/publishing-drafts>
 <https://docs.example.com/guides/blog/promoting-to-public>
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+<http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F>
+<https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F>
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/output/embedded/decoded-email-without-angle-brackets-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/output/embedded/decoded-email-without-angle-brackets-with-crlf-eol.txt
@@ -18,6 +18,15 @@ https://docs.example.com/guides/blog/best-practices
 https://docs.example.com/guides/blog/publishing-drafts
 https://docs.example.com/guides/blog/promoting-to-public
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/output/embedded/decoded-email-without-angle-brackets-with-lf-eol.txt
+++ b/internal/safelinks/testdata/output/embedded/decoded-email-without-angle-brackets-with-lf-eol.txt
@@ -18,6 +18,15 @@ https://docs.example.com/guides/blog/best-practices
 https://docs.example.com/guides/blog/publishing-drafts
 https://docs.example.com/guides/blog/promoting-to-public
 
+P.S.
+
+If you haven't yet, please give the latest release of our linkchecker web app
+a try and let us know what you think! Per request, we offer it in http and
+https variations.
+
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+
 Sincerely,
 
 Bob Smith

--- a/internal/safelinks/testdata/output/standalone/decoded-list-of-urls-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/output/standalone/decoded-list-of-urls-with-crlf-eol.txt
@@ -13,3 +13,5 @@ https://leanpub.com/thekubernetesbook
 https://leanpub.com/dockerdeepdive
 https://www.informit.com/store/unix-and-linux-system-administration-handbook-9780132629454
 https://www.informit.com/store/unix-and-linux-system-administration-handbook-9780134278315
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F

--- a/internal/safelinks/testdata/output/standalone/decoded-list-of-urls-with-lf-eol.txt
+++ b/internal/safelinks/testdata/output/standalone/decoded-list-of-urls-with-lf-eol.txt
@@ -13,3 +13,5 @@ https://leanpub.com/thekubernetesbook
 https://leanpub.com/dockerdeepdive
 https://www.informit.com/store/unix-and-linux-system-administration-handbook-9780132629454
 https://www.informit.com/store/unix-and-linux-system-administration-handbook-9780134278315
+http://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F
+https://www.example.com/linkchecker.php?url=https%3A%2F%2Fwww.google.com%2F


### PR DESCRIPTION
Help ensure that recent changes to require known safelinks "base" domain to be present in Safe Links URLs continutes to function as intended.

Previously, these input URLs would have been incorrectly flagged as Safe Links URLs and "decoded" into the value of the `url` query parameter.

refs GH-251