### PR TITLE
Add angle bracket input support to CLI apps

### DIFF
--- a/cmd/dsl/input.go
+++ b/cmd/dsl/input.go
@@ -89,8 +89,8 @@ func pollInputSource(
 // processInput processes given input replacing any Safe Links encoded URL
 // with the original value. Other input is returned unmodified.
 func processInput(txt string, resultsChan chan<- string, errChan chan<- error) {
-	log.Println("Calling safelinks.SafeLinkURLs")
-	safeLinks, err := safelinks.SafeLinkURLs(txt)
+	log.Println("Calling safelinks.DecodeInput")
+	modifiedInput, err := safelinks.DecodeInput(txt)
 
 	// Failing to find a URL in the input is considered OK. Other errors
 	// result in aborting the decode attempt.
@@ -104,12 +104,6 @@ func processInput(txt string, resultsChan chan<- string, errChan chan<- error) {
 
 		return
 	default:
-		modifiedInput := txt
-
-		for _, sl := range safeLinks {
-			modifiedInput = strings.Replace(modifiedInput, sl.EncodedURL, sl.DecodedURL, 1)
-		}
-
 		resultsChan <- modifiedInput
 	}
 }

--- a/cmd/usl/main.go
+++ b/cmd/usl/main.go
@@ -11,12 +11,20 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
 
 	"github.com/atc0005/safelinks/internal/safelinks"
 )
 
 func main() {
+	// use io.Discard for normal operation
+	// switch to os.Stderr for debugging
+	debugLoggingOut := io.Discard
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	log.SetOutput(debugLoggingOut)
 
 	cfg := NewConfig()
 

--- a/cmd/usl/urls.go
+++ b/cmd/usl/urls.go
@@ -55,13 +55,13 @@ func ReadURLsFromInput(inputURL string) ([]string, error) {
 			return nil, safelinks.ErrInvalidURL
 		}
 
-		inputURLs = append(inputURLs, safelinks.CleanURL(flag.Args()[0]))
+		inputURLs = append(inputURLs, flag.Args()[0])
 
 	// We received a URL via flag.
 	case inputURL != "":
 		// fmt.Fprintln(os.Stderr, "Received URL via flag")
 
-		inputURLs = append(inputURLs, safelinks.CleanURL(inputURL))
+		inputURLs = append(inputURLs, inputURL)
 
 	// Input URL not given via positional argument, not given via flag either.
 	// We prompt the user for a single input value.
@@ -77,7 +77,7 @@ func ReadURLsFromInput(inputURL string) ([]string, error) {
 			return nil, safelinks.ErrInvalidURL
 		}
 
-		inputURLs = append(inputURLs, safelinks.CleanURL(input))
+		inputURLs = append(inputURLs, input)
 	}
 
 	return inputURLs, nil
@@ -95,7 +95,8 @@ func ProcessInputURLs(inputURLs []string, okOut io.Writer, errOut io.Writer, ver
 	var errEncountered bool
 
 	for _, inputURL := range inputURLs {
-		safelink, err := url.Parse(inputURL)
+		cleanedURL := safelinks.CleanURL(inputURL)
+		safelink, err := url.Parse(cleanedURL)
 		if err != nil {
 			fmt.Printf("Failed to parse URL: %v\n", err)
 
@@ -103,7 +104,7 @@ func ProcessInputURLs(inputURLs []string, okOut io.Writer, errOut io.Writer, ver
 			continue
 		}
 
-		if safelinks.ValidSafeLinkURL(safelink) {
+		if !safelinks.ValidSafeLinkURL(safelink) {
 			fmt.Fprintf(errOut, "Invalid Safelinks URL %q\n", safelink)
 
 			errEncountered = true


### PR DESCRIPTION
## Changes

- cmd/usl
  - small refactor to move all URL cleaning behavior from `ReadURLsFromInput` to `ProcessInputURLs`
  - add debug logging toggle to `main` func (disabled by default)
  - fix logic bug with `safelinks.ValidSafeLinkURL` check
- cmd/dsl
  - small refactor to `processInput` func to reuse logic from `safelinks.DecodeInput` (functionality and test coverage)

## References

- GH-246