### PR TITLE
Update workflows to specify OS deps for GUI apps

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -17,8 +17,12 @@ on:
 jobs:
   lint_and_build_using_ci_matrix:
     name: CI matrix
+    with:
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-ci-matrix.yml@master
 
   lint_and_build_using_makefile:
     name: Makefile
+    with:
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
     uses: atc0005/shared-project-resources/.github/workflows/lint-and-build-using-make.yml@master

--- a/.github/workflows/project-analysis.yml
+++ b/.github/workflows/project-analysis.yml
@@ -25,6 +25,8 @@ jobs:
 
   vulnerability:
     name: Vulnerability
+    with:
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
     uses: atc0005/shared-project-resources/.github/workflows/vulnerability-analysis.yml@master
 
   go_mod_validation:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,4 +18,6 @@ jobs:
       contents: write
       discussions: write
 
+    with:
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
     uses: atc0005/shared-project-resources/.github/workflows/release-build.yml@master

--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -18,4 +18,6 @@ on:
 jobs:
   monthly:
     name: Monthly Tasks
+    with:
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-monthly.yml@master

--- a/.github/workflows/scheduled-weekly.yml
+++ b/.github/workflows/scheduled-weekly.yml
@@ -18,4 +18,6 @@ on:
 jobs:
   weekly:
     name: Weekly Tasks
+    with:
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-weekly.yml@master


### PR DESCRIPTION
We require additional OS dependencies in order to build, test and lint GUI apps which use the Fyne toolkit.

refs GH-225