### PR TITLE
Disable internal/safelinks logging by default

### DIFF
--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -36,8 +36,12 @@ import (
 
 func main() {
 	userFeedbackOut := os.Stderr
-	// debugLoggingOut := os.Stderr // switch to os.Stderr for debugging
-	debugLoggingOut := io.Discard // use io.Discard for normal operation
+
+	// use io.Discard for normal operation
+	// switch to os.Stderr for debugging
+	debugLoggingOut := io.Discard
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	log.SetOutput(debugLoggingOut)
 
 	// We wrap the os.Exit() behavior so that we can safely use deferred

--- a/cmd/usl/main.go
+++ b/cmd/usl/main.go
@@ -11,12 +11,20 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
 
 	"github.com/atc0005/safelinks/internal/safelinks"
 )
 
 func main() {
+	// use io.Discard for normal operation
+	// switch to os.Stderr for debugging
+	debugLoggingOut := io.Discard
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	log.SetOutput(debugLoggingOut)
 
 	cfg := NewConfig()
 

--- a/internal/safelinks/init.go
+++ b/internal/safelinks/init.go
@@ -1,0 +1,18 @@
+// Copyright 2022 Adam Chalkley
+//
+// https://github.com/atc0005/safelinks
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package safelinks
+
+import (
+	"io"
+	"log"
+)
+
+func init() {
+	// Disable logging output by default.
+	log.SetOutput(io.Discard)
+}


### PR DESCRIPTION
- discard logging output explicitly per internal/safelinks init func
- continue discarding debug logging for cmd/usl
- continue discarding debug logging for cmd/dsl