### PR TITLE
Evaluate URLs within angle brackets

### DIFF
--- a/cmd/usl/urls.go
+++ b/cmd/usl/urls.go
@@ -55,13 +55,13 @@ func ReadURLsFromInput(inputURL string) ([]string, error) {
 			return nil, safelinks.ErrInvalidURL
 		}
 
-		inputURLs = append(inputURLs, safelinks.CleanURL(flag.Args()[0]))
+		inputURLs = append(inputURLs, flag.Args()[0])
 
 	// We received a URL via flag.
 	case inputURL != "":
 		// fmt.Fprintln(os.Stderr, "Received URL via flag")
 
-		inputURLs = append(inputURLs, safelinks.CleanURL(inputURL))
+		inputURLs = append(inputURLs, inputURL)
 
 	// Input URL not given via positional argument, not given via flag either.
 	// We prompt the user for a single input value.
@@ -77,7 +77,7 @@ func ReadURLsFromInput(inputURL string) ([]string, error) {
 			return nil, safelinks.ErrInvalidURL
 		}
 
-		inputURLs = append(inputURLs, safelinks.CleanURL(input))
+		inputURLs = append(inputURLs, input)
 	}
 
 	return inputURLs, nil


### PR DESCRIPTION
Match URLs enclosed within angle brackets as URL patterns, removing them before parsing and further evaluation as potential Safe Links URLs.

Remove double-cleaning of inputURL left over from earlier refactor work on cmd/usl to "pull back" functionality from the safelinks package.

fixes GH-246