### PR TITLE
Update `github.com/go-text/render` pseudo-version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/fyne-io/image v0.0.0-20240121103648-c3c798e60e6b // indirect
 	github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 // indirect
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240307211618-a69d953ea142 // indirect
-	github.com/go-text/render v0.0.0-20240129162809-b6410f7d78ad // indirect
+	github.com/go-text/render v0.0.0-20240410160112-301cb7dc78d6 // indirect
 	github.com/go-text/typesetting v0.1.1 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,11 +92,11 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240307211618-a69d953ea142 h1:/4YI5K2b16JtP2cL4D2xDNvH/ESm2ZbGJ0VsudkHJ5s=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240307211618-a69d953ea142/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-text/render v0.0.0-20240129162809-b6410f7d78ad h1:JzxbpATK0uq2WpvTX76ofaJA3zuNmYB57FOLuwpRPPs=
-github.com/go-text/render v0.0.0-20240129162809-b6410f7d78ad/go.mod h1:Yww7wr2yRAWo3zKRPO2rc155nccyXcE9FwyXXm9ys+w=
+github.com/go-text/render v0.0.0-20240410160112-301cb7dc78d6 h1:zaK68PaoSbCSrDIFOYvsQXHW18KAi6gwmu6MFl2gheo=
+github.com/go-text/render v0.0.0-20240410160112-301cb7dc78d6/go.mod h1:jqEuNMenrmj6QRnkdpeaP0oKGFLDNhDkVKwGjsWWYU4=
 github.com/go-text/typesetting v0.1.1 h1:bGAesCuo85nXnEN5LmFMVGAGpGkCPtHrZLi//qD7EJo=
 github.com/go-text/typesetting v0.1.1/go.mod h1:d22AnmeKq/on0HNv73UFriMKc4Ez6EqZAofLhAzpSzI=
-github.com/go-text/typesetting-utils v0.0.0-20231211103740-d9332ae51f04 h1:zBx+p/W2aQYtNuyZNcTfinWvXBQwYtDfme051PR/lAY=
+github.com/go-text/typesetting-utils v0.0.0-20240329101916-eee87fb235a3 h1:levTnuLLUmpavLGbJYLJA7fQnKeS7P1eCdAlM+vReXk=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/vendor/github.com/go-text/render/bitmap.go
+++ b/vendor/github.com/go-text/render/bitmap.go
@@ -15,6 +15,10 @@ import (
 )
 
 func (r *Renderer) drawBitmap(g shaping.Glyph, bitmap api.GlyphBitmap, img draw.Image, x, y float32) error {
+	// scaled glyph rect content
+	top := y - fixed266ToFloat(g.YBearing)*r.PixScale
+	bottom := top - fixed266ToFloat(g.Height)*r.PixScale
+	right := x + fixed266ToFloat(g.Width)*r.PixScale
 	switch bitmap.Format {
 	case api.BlackAndWhite:
 		rec := image.Rect(0, 0, bitmap.Width, bitmap.Height)
@@ -53,7 +57,7 @@ func (r *Renderer) drawBitmap(g shaping.Glyph, bitmap api.GlyphBitmap, img draw.
 			}
 		}
 
-		rect := image.Rect(int(x), int(y), int(x+fixed266ToFloat(g.Width)*r.PixScale), int(y-fixed266ToFloat(g.Height)*r.PixScale))
+		rect := image.Rect(int(x), int(top), int(right), int(bottom))
 		scale.NearestNeighbor.Scale(img, rect, sub, sub.Bounds(), draw.Over, nil)
 	case api.JPG, api.PNG, api.TIFF:
 		pix, _, err := image.Decode(bytes.NewReader(bitmap.Data))
@@ -61,7 +65,7 @@ func (r *Renderer) drawBitmap(g shaping.Glyph, bitmap api.GlyphBitmap, img draw.
 			return err
 		}
 
-		rect := image.Rect(int(x), int(y), int(x+fixed266ToFloat(g.Width)*r.PixScale), int(y-fixed266ToFloat(g.Height)*r.PixScale))
+		rect := image.Rect(int(x), int(top), int(right), int(bottom))
 		scale.BiLinear.Scale(img, rect, pix, pix.Bounds(), draw.Over, nil)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,7 +79,7 @@ github.com/go-gl/glfw/v3.3/glfw/glfw/deps/mingw
 github.com/go-gl/glfw/v3.3/glfw/glfw/deps/vs2008
 github.com/go-gl/glfw/v3.3/glfw/glfw/include/GLFW
 github.com/go-gl/glfw/v3.3/glfw/glfw/src
-# github.com/go-text/render v0.0.0-20240129162809-b6410f7d78ad
+# github.com/go-text/render v0.0.0-20240410160112-301cb7dc78d6
 ## explicit; go 1.17
 github.com/go-text/render
 # github.com/go-text/typesetting v0.1.1


### PR DESCRIPTION
```text
github.com/go-text/render
    from v0.0.0-20240129162809-b6410f7d78ad
    to   v0.0.0-20240410160112-301cb7dc78d6
```

Applied via:

1. `go get -u ./...`
2. `go mod tidy`
3. `go mod vendor`