### PR TITLE
Enable i386 arch for Makefile `all` builds

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -15,9 +15,26 @@ on:
     # * * * * *
     - cron: "30 4 1 * *"
 
+  # Allow triggering workflow manually
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+
 jobs:
   monthly:
     name: Monthly Tasks
     with:
-      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
+      # As specified here, the called workflow adds the i386 architecture to
+      # allow installing i386 package variants within a Debian-based x64 OS.
+      makefile-enable-i386-architecture: true
+
+      # We provide dependencies used for building CGO-enabled x86 and x64
+      # assets within a x64 environment.
+      #
+      # NOTE: The *:i386 packages are only available once the i386
+      # architecture has been explicitly added within the build environment.
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev libxinerama-dev:i386 libgl1-mesa-dev:i386 libxrandr-dev:i386 libxxf86vm-dev:i386 libxi-dev:i386 libxcursor-dev:i386"
+
+      # Explicitly opt into running `make all` as part of scheduled monthly
+      # test build tasks.
+      makefile-build-all: true
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-monthly.yml@master

--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,9 @@ depsinstall:
 	@echo "Installing latest git-describe-semver version ..."
 	go install github.com/choffmeister/git-describe-semver@latest
 
+	@echo "NOTE: Review README directions for additional Linux x86 build requirements."
+	@echo "NOTE: See also docker-release-build and podman-release-build Makefile recipes."
+
 	@echo "Finished installing or updating build dependencies"
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ this requirement and will require building from source.
 ### From source
 
 > [!TIP]
-> Use `make docker-release-build` or `podman-release-build` Makefile recipes to use generate/use build containers compatible with this project.
+> Use `docker-release-build` or `podman-release-build` Makefile recipes to use build containers compatible with this project.
 
 1. [Download][go-docs-download] Go
 1. [Install][go-docs-install] Go
@@ -198,9 +198,19 @@ this requirement and will require building from source.
    1. `cd safelinks`
 1. Install dependencies (optional)
    - for Ubuntu Linux
-     - `sudo apt-get install make gcc libgl1-mesa-dev xorg-dev`
+     - if building for the current architecture
+       - `sudo apt-get install make gcc xz-utils libgl1-mesa-dev xorg-dev`
+     - if building x86 binaries on x64 OS
+       - `sudo dpkg --add-architecture i386`
+       - `sudo dpkg --configure -a`
+       - `sudo apt-get update`
+       - `sudo apt-get install make bsdmainutils gcc gcc-multilib
+         gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev`
+       - `sudo apt-get install libxinerama-dev:i386 libgl1-mesa-dev:i386
+         libxrandr-dev:i386 libxxf86vm-dev:i386 libxi-dev:i386
+         libxcursor-dev:i386`
    - for CentOS Linux
-     1. `sudo yum install make gcc gcc libXcursor-devel libXrandr-devel
+     1. `sudo yum install make gcc libXcursor-devel libXrandr-devel
         mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
 1. Build
    - for the detected current operating system and architecture, explicitly
@@ -263,7 +273,7 @@ binaries.
 1. Place `eslg` in a location where it can be easily accessed
 
 > [!NOTE]
-> The `libgl1` package was needed on target Ubuntu systems for the `dslg` and `eslg` apps.
+> The `libgl1` package is needed on target Ubuntu systems for the `dslg` and `eslg` apps.
 
 ## Configuration
 


### PR DESCRIPTION
## Changes

- update `scheduled-monthly.yml` workflow
  - explicitly enable `makefile-enable-i386-architecture` input
  - explicitly enable `makefile-build-all` input
  - explicitly enable `workflow_dispatch` setting to allow manually triggered execution (mostly for troubleshooting)
  - expand `os-dependencies` input list to include `i386` arch packages to allow building Linux x86 Fyne toolkit dependent binaries as part of scheduled monthly `make all` invocation on Ubuntu x64 OS
- update `Makefile`
  - update `depsinstall` recipe to note that there are additional build requirements for Linux x86 assets on Linux x64 OS
- update `README.md`
  - expand dependencies coverage for the building from source section - add steps for enabling `i386` architecture on Ubuntu x64 OS - add `i386` arch packages
  - minor wording tweaks

## References

- fixes GH-325