### PR TITLE
Rework support for i386 arch for Makefile `all`

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -25,14 +25,21 @@ jobs:
     with:
       # As specified here, the called workflow adds the i386 architecture to
       # allow installing i386 package variants within a Debian-based x64 OS.
+      #
+      # refs https://github.com/atc0005/safelinks/issues/325
       makefile-enable-i386-architecture: true
 
-      # We provide dependencies used for building CGO-enabled x86 and x64
-      # assets within a x64 environment.
+      # Dependencies used for building CGO-enabled x64 assets.
+      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev"
+
+      # Optional additional set of OS dependencies intended specifically for
+      # the Makefile `all` recipe.
       #
-      # NOTE: The *:i386 packages are only available once the i386
+      # NOTE: These *:i386 packages are only available once the i386
       # architecture has been explicitly added within the build environment.
-      os-dependencies: "make bsdmainutils gcc gcc-multilib gcc-mingw-w64 xz-utils libgl1-mesa-dev xorg-dev libxinerama-dev:i386 libgl1-mesa-dev:i386 libxrandr-dev:i386 libxxf86vm-dev:i386 libxi-dev:i386 libxcursor-dev:i386"
+      #
+      # refs https://github.com/atc0005/safelinks/issues/325
+      makefile-all-os-dependencies: "libxinerama-dev:i386 libgl1-mesa-dev:i386 libxrandr-dev:i386 libxxf86vm-dev:i386 libxi-dev:i386 libxcursor-dev:i386"
 
       # Explicitly opt into running `make all` as part of scheduled monthly
       # test build tasks.


### PR DESCRIPTION
Use new called workflow `makefile-all-os-dependencies` input to specify dependencies specific to the Makefile `all` recipe where this calling workflow also explicitly requests enabling the installation of i386 architecture packages.

fixes GH-325