### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -90,10 +90,10 @@ func main() {
 			return
 
 		case result := <-resultsChan:
-			fmt.Fprintln(os.Stdout, result)
+			_, _ = fmt.Fprintln(os.Stdout, result)
 
 		case err := <-errChan:
-			fmt.Fprintln(userFeedbackOut, err.Error())
+			_, _ = fmt.Fprintln(userFeedbackOut, err.Error())
 			appExitCode = 1
 
 			return

--- a/cmd/dsl/shutdown.go
+++ b/cmd/dsl/shutdown.go
@@ -43,7 +43,7 @@ func shutdownListener(
 
 	select {
 	case <-timer.C:
-		fmt.Fprintln(w, "Timeout reached. Exiting application.")
+		_, _ = fmt.Fprintln(w, "Timeout reached. Exiting application.")
 
 		log.Println("Calling cancel func")
 		cancel()
@@ -69,9 +69,9 @@ func shutdownListener(
 		}
 
 		if gracefulShutdownSignal {
-			fmt.Fprintln(w, gracefulExitMsg)
+			_, _ = fmt.Fprintln(w, gracefulExitMsg)
 		} else {
-			fmt.Fprintln(w, failureExitMsg)
+			_, _ = fmt.Fprintln(w, failureExitMsg)
 		}
 
 		done <- true

--- a/cmd/dsl/usage.go
+++ b/cmd/dsl/usage.go
@@ -34,14 +34,14 @@ func showAppUsageInfo(appInput *os.File, timerDuration time.Duration, appOutput 
 		//
 		// To keep things simple, it is best to only advertise Ctrl-C or
 		// waiting for the configured timeout to stop input processing.
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			appOutput,
 			"Enter single or multi-line input. Press Ctrl-C to stop "+
 				"(or wait %v for timeout).\n\n",
 			timerDuration,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			appOutput,
 			"  - Feedback from this app is sent to stderr.\n"+
 				"  - Decoding results are sent to stdout.\n"+

--- a/cmd/usl/config.go
+++ b/cmd/usl/config.go
@@ -52,8 +52,8 @@ func Version() string {
 // usage is a custom override for the default Help text provided by the flag
 // package. Here we prepend some additional metadata to the existing output.
 func usage() {
-	fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+	_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	flag.PrintDefaults()
 }
 

--- a/cmd/usl/main.go
+++ b/cmd/usl/main.go
@@ -41,13 +41,13 @@ func main() {
 	case cfg.Filename != "":
 		f, err := os.Open(cfg.Filename)
 		if err != nil {
-			fmt.Fprintf(userFeedbackOut, "Failed to open %q: %v\n", cfg.Filename, err)
+			_, _ = fmt.Fprintf(userFeedbackOut, "Failed to open %q: %v\n", cfg.Filename, err)
 			os.Exit(1)
 		}
 
 		input, err := safelinks.ReadFromFile(f)
 		if err != nil {
-			fmt.Fprintf(userFeedbackOut, "Failed to read URLs from %q: %v\n", cfg.Filename, err)
+			_, _ = fmt.Fprintf(userFeedbackOut, "Failed to read URLs from %q: %v\n", cfg.Filename, err)
 			os.Exit(1)
 		}
 
@@ -56,7 +56,7 @@ func main() {
 	default:
 		input, err := ReadURLsFromInput(cfg.URL)
 		if err != nil {
-			fmt.Fprintf(userFeedbackOut, "Failed to parse input as URL: %v\n", err)
+			_, _ = fmt.Fprintf(userFeedbackOut, "Failed to parse input as URL: %v\n", err)
 			os.Exit(1)
 		}
 

--- a/cmd/usl/output.go
+++ b/cmd/usl/output.go
@@ -32,7 +32,7 @@ func simpleOutput(u *url.URL, w io.Writer) {
 	urlValues := u.Query()
 	maskedURL := urlValues.Get("url")
 
-	fmt.Fprintln(w, maskedURL)
+	_, _ = fmt.Fprintln(w, maskedURL)
 }
 
 // verboseOutput handles generating extended or "verbose" output when
@@ -47,11 +47,11 @@ func verboseOutput(u *url.URL, w io.Writer) {
 	}
 	sort.Strings(keys)
 
-	fmt.Fprintf(w, "\nExpanded values from the given link:\n\n")
+	_, _ = fmt.Fprintf(w, "\nExpanded values from the given link:\n\n")
 
 	for _, key := range keys {
 		if len(urlValues[key]) > 0 {
-			fmt.Fprintf(w, "  %-10s: %s\n", key, urlValues[key][0])
+			_, _ = fmt.Fprintf(w, "  %-10s: %s\n", key, urlValues[key][0])
 		}
 	}
 }

--- a/cmd/usl/urls.go
+++ b/cmd/usl/urls.go
@@ -43,13 +43,13 @@ func ReadURLsFromInput(inputURL string) ([]string, error) {
 
 	// We received one or more URLs via standard input.
 	case (stat.Mode() & os.ModeCharDevice) == 0:
-		// fmt.Fprintln(os.Stderr, "Received URL via standard input")
+		// _, _ = fmt.Fprintln(os.Stderr, "Received URL via standard input")
 		return safelinks.ReadFromFile(os.Stdin)
 
 	// We received a URL via positional argument. We ignore all but the first
 	// one.
 	case len(flag.Args()) > 0:
-		// fmt.Fprintln(os.Stderr, "Received URL via positional argument")
+		// _, _ = fmt.Fprintln(os.Stderr, "Received URL via positional argument")
 
 		if strings.TrimSpace(flag.Args()[0]) == "" {
 			return nil, safelinks.ErrInvalidURL
@@ -59,14 +59,14 @@ func ReadURLsFromInput(inputURL string) ([]string, error) {
 
 	// We received a URL via flag.
 	case inputURL != "":
-		// fmt.Fprintln(os.Stderr, "Received URL via flag")
+		// _, _ = fmt.Fprintln(os.Stderr, "Received URL via flag")
 
 		inputURLs = append(inputURLs, inputURL)
 
 	// Input URL not given via positional argument, not given via flag either.
 	// We prompt the user for a single input value.
 	default:
-		// fmt.Fprintln(os.Stderr, "default switch case triggered")
+		// _, _ = fmt.Fprintln(os.Stderr, "default switch case triggered")
 
 		input, err := safelinks.ReadURLFromUser()
 		if err != nil {
@@ -98,14 +98,14 @@ func ProcessInputURLs(inputURLs []string, okOut io.Writer, errOut io.Writer, ver
 		cleanedURL := safelinks.CleanURL(inputURL)
 		safelink, err := url.Parse(cleanedURL)
 		if err != nil {
-			fmt.Fprintf(errOut, "Failed to parse URL: %v\n", err)
+			_, _ = fmt.Fprintf(errOut, "Failed to parse URL: %v\n", err)
 
 			errEncountered = true
 			continue
 		}
 
 		if !safelinks.ValidSafeLinkURL(safelink) {
-			fmt.Fprintf(errOut, "Invalid Safelinks URL %q\n", safelink)
+			_, _ = fmt.Fprintf(errOut, "Invalid Safelinks URL %q\n", safelink)
 
 			errEncountered = true
 			continue


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by explicitly discarding return values (potential error, bytes written) since we do not need them and the potential for failure (in this particular use case) is *highly* unlikely.