### PR TITLE
Fix decoding of Markdown formatted URLs

### DIFF
--- a/internal/safelinks/exported_test.go
+++ b/internal/safelinks/exported_test.go
@@ -81,6 +81,12 @@ var (
 	//go:embed testdata/output/standalone/decoded-list-of-urls-with-lf-eol.txt
 	outputDecodedListOfURLsWithLFEol string
 
+	//go:embed testdata/output/standalone/decoded-list-of-markdown-formatted-urls-with-crlf-eol.txt
+	outputDecodedListOfMarkdownFormattedURLsWithCRLFEol string
+
+	//go:embed testdata/output/standalone/decoded-list-of-markdown-formatted-urls-with-lf-eol.txt
+	outputDecodedListOfMarkdownFormattedURLsWithLFEol string
+
 	//go:embed testdata/output/standalone/decoded-single-url-with-angle-brackets-with-crlf-eol.txt
 	outputDecodedSingleURLWithAngleBracketsWithCRLFEol string
 
@@ -129,6 +135,12 @@ var (
 
 	//go:embed testdata/input/encoded-all/list-of-urls-with-lf-eol.txt
 	inputEncodedAllListOfURLsWithLFEol string
+
+	//go:embed testdata/input/encoded-all/list-of-markdown-formatted-urls-with-crlf-eol.txt
+	inputEncodedAllListOfMarkdownFormattedURLsWithCRLFEol string
+
+	//go:embed testdata/input/encoded-all/list-of-markdown-formatted-urls-with-lf-eol.txt
+	inputEncodedAllListOfMarkdownFormattedURLsWithLFEol string
 )
 
 // The format used by the test files is VERY specific; trailing space plus
@@ -247,6 +259,14 @@ func TestURLsFindsAllValidURLs(t *testing.T) {
 		"Encoded list of URLs with CRLF EOL": {
 			input:          inputEncodedAllListOfURLsWithCRLFEol,
 			foundURLsCount: 17,
+		},
+		"Encoded list of Markdown formatted URLs with LF EOL": {
+			input:          inputEncodedAllListOfMarkdownFormattedURLsWithLFEol,
+			foundURLsCount: 2,
+		},
+		"Encoded list of Markdown formatted URLs with CRLF EOL": {
+			input:          inputEncodedAllListOfMarkdownFormattedURLsWithCRLFEol,
+			foundURLsCount: 2,
 		},
 		"Encoded single URL with angle brackets with LF EOL": {
 			input:          inputEncodedSingleSafelinksURLWithAngleBracketsWithLFEol,
@@ -489,6 +509,16 @@ func TestFilterURLsCorrectlyFiltersByType(t *testing.T) {
 			foundEncodedLinksURLsCount: 17,
 			foundUnencodedURLsCount:    0,
 		},
+		"Encoded list of Markdown formatted URLs with CRLF EOL": {
+			input:                      inputEncodedAllListOfMarkdownFormattedURLsWithCRLFEol,
+			foundEncodedLinksURLsCount: 2,
+			foundUnencodedURLsCount:    0,
+		},
+		"Encoded list of Markdown formatted URLs with LF EOL": {
+			input:                      inputEncodedAllListOfMarkdownFormattedURLsWithLFEol,
+			foundEncodedLinksURLsCount: 2,
+			foundUnencodedURLsCount:    0,
+		},
 		"Encoded single URL with angle brackets with LF EOL": {
 			input:                      inputEncodedSingleSafelinksURLWithAngleBracketsWithLFEol,
 			foundEncodedLinksURLsCount: 1,
@@ -658,6 +688,14 @@ func TestSafeLinkURLsFindsAllValidSafeLinks(t *testing.T) {
 			input:                 inputEncodedAllListOfURLsWithLFEol,
 			foundEncodedURLsCount: 17,
 		},
+		"Encoded list of Markdown formatted URLs with CRLF EOL": {
+			input:                 inputEncodedAllListOfMarkdownFormattedURLsWithCRLFEol,
+			foundEncodedURLsCount: 2,
+		},
+		"Encoded list of Markdown formatted URLs with LF EOL": {
+			input:                 inputEncodedAllListOfMarkdownFormattedURLsWithLFEol,
+			foundEncodedURLsCount: 2,
+		},
 		"Encoded single URL with angle brackets with LF EOL": {
 			input:                 inputEncodedSingleSafelinksURLWithAngleBracketsWithLFEol,
 			foundEncodedURLsCount: 1,
@@ -752,6 +790,14 @@ func TestDecodeInputSucceedsForValidInput(t *testing.T) {
 		"Encoded list of URLs with CRLF EOL": {
 			input:  inputEncodedAllListOfURLsWithCRLFEol,
 			result: outputDecodedListOfURLsWithCRLFEol,
+		},
+		"Encoded list of Markdown formatted URLs with LF EOL": {
+			input:  inputEncodedAllListOfMarkdownFormattedURLsWithLFEol,
+			result: outputDecodedListOfMarkdownFormattedURLsWithLFEol,
+		},
+		"Encoded list of Markdown formatted URLs with CRLF EOL": {
+			input:  inputEncodedAllListOfMarkdownFormattedURLsWithCRLFEol,
+			result: outputDecodedListOfMarkdownFormattedURLsWithCRLFEol,
 		},
 		"Encoded single URL with angle brackets with LF EOL": {
 			input:  inputEncodedSingleSafelinksURLWithAngleBracketsWithLFEol,

--- a/internal/safelinks/safelinks.go
+++ b/internal/safelinks/safelinks.go
@@ -206,6 +206,10 @@ func trimEnclosingURLCharacters(url string) string {
 	// Remove potential enclosing angle brackets.
 	url = strings.Trim(url, `<>`)
 
+	// Remove potential enclosing parenthesis used with Markdown formatted
+	// URLs.
+	url = strings.Trim(url, `()`)
+
 	return url
 }
 
@@ -306,7 +310,7 @@ func GetURLPatternsUsingRegex(input string, evalPlainHTTP bool) ([]FoundURLPatte
 // whitespace character or a right angle bracket. The caller is responsible
 // for trimming angle brackets and other unwanted characters.
 func GetURLPatternsUsingIndex(input string, evalAllHTTPURLs bool) ([]FoundURLPattern, error) {
-	if !strings.Contains(input, SafeLinksURLRequiredPrefix) && !evalAllHTTPURLs {
+	if !hasAcceptableURLPrefix(input, evalAllHTTPURLs) {
 		return nil, ErrNoURLsFound
 	}
 

--- a/internal/safelinks/testdata/input/encoded-all/list-of-markdown-formatted-urls-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-all/list-of-markdown-formatted-urls-with-crlf-eol.txt
@@ -1,0 +1,2 @@
+[Retirement of Office 365 connectors within Microsoft Teams](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdevblogs.microsoft.com%2Fmicrosoft365dev%2Fretirement-of-office-365-connectors-within-microsoft-teams%2F&data=data_placeholder&sdata=sdata_placeholder&reserved=0)
+[Retirement of Office 365 connectors within Microsoft Teams](https://nam10.safelinks.protection.outlook.com/?url=https%3A%2F%2Faka.ms%2FO365ConnectorDeprecation&data=data_placeholder&sdata=sdata_placeholder&reserved=0)

--- a/internal/safelinks/testdata/input/encoded-all/list-of-markdown-formatted-urls-with-lf-eol.txt
+++ b/internal/safelinks/testdata/input/encoded-all/list-of-markdown-formatted-urls-with-lf-eol.txt
@@ -1,0 +1,2 @@
+[Retirement of Office 365 connectors within Microsoft Teams](https://nam11.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdevblogs.microsoft.com%2Fmicrosoft365dev%2Fretirement-of-office-365-connectors-within-microsoft-teams%2F&data=data_placeholder&sdata=sdata_placeholder&reserved=0)
+[Retirement of Office 365 connectors within Microsoft Teams](https://nam10.safelinks.protection.outlook.com/?url=https%3A%2F%2Faka.ms%2FO365ConnectorDeprecation&data=data_placeholder&sdata=sdata_placeholder&reserved=0)

--- a/internal/safelinks/testdata/output/standalone/decoded-list-of-markdown-formatted-urls-with-crlf-eol.txt
+++ b/internal/safelinks/testdata/output/standalone/decoded-list-of-markdown-formatted-urls-with-crlf-eol.txt
@@ -1,0 +1,2 @@
+[Retirement of Office 365 connectors within Microsoft Teams](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/)
+[Retirement of Office 365 connectors within Microsoft Teams](https://aka.ms/O365ConnectorDeprecation)

--- a/internal/safelinks/testdata/output/standalone/decoded-list-of-markdown-formatted-urls-with-lf-eol.txt
+++ b/internal/safelinks/testdata/output/standalone/decoded-list-of-markdown-formatted-urls-with-lf-eol.txt
@@ -1,0 +1,2 @@
+[Retirement of Office 365 connectors within Microsoft Teams](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/)
+[Retirement of Office 365 connectors within Microsoft Teams](https://aka.ms/O365ConnectorDeprecation)


### PR DESCRIPTION
## Changes

- Add test cases for Markdown formatted URLs
  - assert that Markdown formatted URLs decode as expected without
    trimming right parenthesis
- Fix decoding logic
  - extend `trimEnclosingURLCharacters` helper func to remove left and
  right parenthesis from matched URL pattern to prevent parenthesis
  from being unintentionally removed when search/replace operation is
  performed against original text to preserve syntax for Markdown
  formatted URLs
- Update logic in `GetURLPatternsUsingIndex` to resolve failing
  `TestURLsFailsForInvalidURLs` test cases by using the same
  `hasAcceptableURLPrefix` helper func as the
  `GetURLPatternsUsingRegex` func

## References

- fixes GH-442