### PR TITLE
Update `golang.org/x/mobile` pseudo-version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect
 	golang.org/x/image v0.20.0 // indirect
-	golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab // indirect
+	golang.org/x/mobile v0.0.0-20240909163608-642950227fb3 // indirect
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect
 	golang.org/x/text v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,8 @@ golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mobile v0.0.0-20211207041440-4e6c2922fdee/go.mod h1:pe2sM7Uk+2Su1y7u/6Z8KJ24D7lepUjFZbhFOrmDfuQ=
-golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab h1:KONOFF8Uy3b60HEzOsGnNghORNhY4ImyOx0PGm73K9k=
-golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab/go.mod h1:udWezQGYjqrCxz5nV321pXQTx5oGbZx+khZvFjZNOPM=
+golang.org/x/mobile v0.0.0-20240909163608-642950227fb3 h1:HOa20LMHFElnLsGI9j8/sxTIHpogkTuHZlyoIjl3kkw=
+golang.org/x/mobile v0.0.0-20240909163608-642950227fb3/go.mod h1:5EJr05J3jS1A5hwVNxs4vC0pIRxtWmwM15D1ZxCj93s=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,8 +176,8 @@ golang.org/x/image/math/fixed
 golang.org/x/image/tiff
 golang.org/x/image/tiff/lzw
 golang.org/x/image/vector
-# golang.org/x/mobile v0.0.0-20240806205939-81131f6468ab
-## explicit; go 1.18
+# golang.org/x/mobile v0.0.0-20240909163608-642950227fb3
+## explicit; go 1.22.0
 golang.org/x/mobile/exp/f32
 # golang.org/x/net v0.29.0
 ## explicit; go 1.18


### PR DESCRIPTION
```text
golang.org/x/mobile
    from v0.0.0-20240806205939-81131f6468ab
    to   v0.0.0-20240909163608-642950227fb3
```

Applied via:

1. `go get -u ./...`
2. `go mod tidy`
3. `go mod vendor`