### PR TITLE
Update `jeandeaual/go-locale` pseudo-version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/go-text/typesetting v0.2.1 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
-	github.com/jeandeaual/go-locale v0.0.0-20241204123234-32dda1c00a20 // indirect
+	github.com/jeandeaual/go-locale v0.0.0-20241217141322-fcc2cadd6f08 // indirect
 	github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25 // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.4.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jeandeaual/go-locale v0.0.0-20241204123234-32dda1c00a20 h1:S6sn9jRW3oq1k/Qiwa20F+E57ZVJ2+KB1Vp5xiJ1FlI=
-github.com/jeandeaual/go-locale v0.0.0-20241204123234-32dda1c00a20/go.mod h1:pYcXQtDPRThfL37oZEzUVo2Jb8ua0NEC7rZqrxXyuhA=
+github.com/jeandeaual/go-locale v0.0.0-20241217141322-fcc2cadd6f08 h1:wMeVzrPO3mfHIWLZtDcSaGAe2I4PW9B/P5nMkRSwCAc=
+github.com/jeandeaual/go-locale v0.0.0-20241217141322-fcc2cadd6f08/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=

--- a/vendor/github.com/jeandeaual/go-locale/.gitignore
+++ b/vendor/github.com/jeandeaual/go-locale/.gitignore
@@ -1,7 +1,5 @@
 examples/getlocale/getlocale
 examples/getlocale/getlocale.exe
-examples/getlocale-gui/getlocale-gui
-examples/getlocale-gui/getlocale-gui.exe
 
 ### Go ###
 # Binaries for programs and plugins

--- a/vendor/github.com/jeandeaual/go-locale/README.md
+++ b/vendor/github.com/jeandeaual/go-locale/README.md
@@ -103,8 +103,6 @@ func main() {
 }
 ```
 
-For a complete example, see [here](examples/getlocale-gui/main.go).
-
 ## GetLocale
 
 `GetLocale` returns the current locale as defined in [IETF BCP 47](https://tools.ietf.org/rfc/bcp/bcp47.txt) (e.g. `"en-US"`).

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,7 +121,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/gopherjs/gopherjs v1.17.2
 ## explicit; go 1.17
 github.com/gopherjs/gopherjs/js
-# github.com/jeandeaual/go-locale v0.0.0-20241204123234-32dda1c00a20
+# github.com/jeandeaual/go-locale v0.0.0-20241217141322-fcc2cadd6f08
 ## explicit; go 1.18
 github.com/jeandeaual/go-locale
 # github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25


### PR DESCRIPTION
```text
github.com/jeandeaual/go-locale
    from v0.0.0-20241204123234-32dda1c00a20
    to   v0.0.0-20241217141322-fcc2cadd6f08
```

Applied via:

1. `go get -u github.com/jeandeaual/go-locale@latest`
2. `go mod tidy`
3. `go mod vendor`