### PR TITLE
Fix deprecated func use after fyne v2.6.0 update

### DIFF
--- a/cmd/dslg/buttons.go
+++ b/cmd/dslg/buttons.go
@@ -17,10 +17,10 @@ import (
 	"github.com/atc0005/safelinks/internal/safelinks"
 )
 
-func newCopyButton(w fyne.Window, outputField *widget.Label) *widget.Button {
+func newCopyButton(a fyne.App, outputField *widget.Label) *widget.Button {
 	copyButton := widget.NewButton("Copy to Clipboard", func() {
 		log.Println("Copying decoded text to clipboard")
-		w.Clipboard().SetContent(outputField.Text)
+		a.Clipboard().SetContent(outputField.Text)
 	})
 
 	copyButton.Importance = widget.DangerImportance

--- a/cmd/dslg/main.go
+++ b/cmd/dslg/main.go
@@ -32,7 +32,7 @@ func main() {
 	errorOutput := NewErrorOutputTextField()
 	output := NewOutputTextLabel()
 
-	copyButton := newCopyButton(w, output)
+	copyButton := newCopyButton(a, output)
 	decodeButton := newDecodeButton(input, copyButton, errorOutput, output)
 	resetButton := newResetButton(w, input, copyButton, errorOutput, output)
 	aboutButton := newAboutButton(w, input, copyButton, errorOutput, output)

--- a/cmd/eslg/buttons.go
+++ b/cmd/eslg/buttons.go
@@ -18,10 +18,10 @@ import (
 	"github.com/atc0005/safelinks/internal/safelinks"
 )
 
-func newCopyButton(w fyne.Window, outputField *widget.Label) *widget.Button {
+func newCopyButton(a fyne.App, outputField *widget.Label) *widget.Button {
 	copyButton := widget.NewButton("Copy to Clipboard", func() {
 		log.Println("Copying decoded text to clipboard")
-		w.Clipboard().SetContent(outputField.Text)
+		a.Clipboard().SetContent(outputField.Text)
 	})
 
 	copyButton.Importance = widget.DangerImportance

--- a/cmd/eslg/main.go
+++ b/cmd/eslg/main.go
@@ -43,7 +43,7 @@ func main() {
 	errorOutput := NewErrorOutputTextField()
 	output := NewOutputTextLabel()
 
-	copyButton := newCopyButton(w, output)
+	copyButton := newCopyButton(a, output)
 	encodeAllButton := newEncodeButton(false, input, copyButton, errorOutput, output)
 	encodeRandomButton := newEncodeButton(true, input, copyButton, errorOutput, output)
 	queryEscapeAllButton := newQueryEscapeButton(false, input, copyButton, errorOutput, output)


### PR DESCRIPTION
This commit resolves:

SA1019: w.Clipboard is deprecated: use App.Clipboard() instead