### PR TITLE
Update `jeandeaual/go-locale` pseudo-version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/hack-pad/go-indexeddb v0.3.2 // indirect
 	github.com/hack-pad/safejs v0.1.1 // indirect
-	github.com/jeandeaual/go-locale v0.0.0-20241217141322-fcc2cadd6f08 // indirect
+	github.com/jeandeaual/go-locale v0.0.0-20250421151639-a9d6ed1b3d45 // indirect
 	github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/hack-pad/go-indexeddb v0.3.2 h1:DTqeJJYc1usa45Q5r52t01KhvlSN02+Oq+tQb
 github.com/hack-pad/go-indexeddb v0.3.2/go.mod h1:QvfTevpDVlkfomY498LhstjwbPW6QC4VC/lxYb0Kom0=
 github.com/hack-pad/safejs v0.1.1 h1:d5qPO0iQ7h2oVtpzGnLExE+Wn9AtytxIfltcS2b9KD8=
 github.com/hack-pad/safejs v0.1.1/go.mod h1:HdS+bKF1NrE72VoXZeWzxFOVQVUSqZJAG0xNCnb+Tio=
-github.com/jeandeaual/go-locale v0.0.0-20241217141322-fcc2cadd6f08 h1:wMeVzrPO3mfHIWLZtDcSaGAe2I4PW9B/P5nMkRSwCAc=
-github.com/jeandeaual/go-locale v0.0.0-20241217141322-fcc2cadd6f08/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
+github.com/jeandeaual/go-locale v0.0.0-20250421151639-a9d6ed1b3d45 h1:vFdvrlsVU+p/KFBWTq0lTG4fvWvG88sawGlCzM+RUEU=
+github.com/jeandeaual/go-locale v0.0.0-20250421151639-a9d6ed1b3d45/go.mod h1:ZDXo8KHryOWSIqnsb/CiDq7hQUYryCgdVnxbj8tDG7o=
 github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25 h1:YLvr1eE6cdCqjOe972w/cYF+FjW34v27+9Vo5106B4M=
 github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25/go.mod h1:kLgvv7o6UM+0QSf0QjAse3wReFDsb9qbZJdfexWlrQw=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/vendor/github.com/jeandeaual/go-locale/locale_darwin_cgo.go
+++ b/vendor/github.com/jeandeaual/go-locale/locale_darwin_cgo.go
@@ -1,0 +1,43 @@
+//go:build darwin && !ios
+
+package locale
+
+// Non-CGO implementation is in locale_darwin_nocgo.go
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation
+
+#include <AppKit/AppKit.h>
+
+const char * preferredLocalization();
+const char * preferredLocalizations();
+*/
+import "C"
+import (
+	"strings"
+)
+
+// GetLocale retrieves the IETF BCP 47 language tag set on the system.
+func GetLocale() (string, error) {
+	str := C.preferredLocalization()
+	if output := C.GoString(str); output != "" {
+		return strings.Replace(output, "_", "-", 1), nil
+	}
+
+	return getLocaleCli()
+}
+
+// GetLocales retrieves the IETF BCP 47 language tags set on the system.
+func GetLocales() ([]string, error) {
+	str := C.preferredLocalizations()
+	if output := C.GoString(str); output != "" {
+		r := []string{}
+		for _, s := range strings.Split(output, ",") {
+			r = append(r, strings.Replace(s, "_", "-", 1))
+		}
+		return r, nil
+	}
+
+	return getLocalesCli()
+}

--- a/vendor/github.com/jeandeaual/go-locale/locale_darwin_nocgo.go
+++ b/vendor/github.com/jeandeaual/go-locale/locale_darwin_nocgo.go
@@ -1,0 +1,13 @@
+//go:build darwin && !ios && !cgo
+
+package locale
+
+// GetLocale retrieves the IETF BCP 47 language tag set on the system.
+func GetLocale() (string, error) {
+	return getLocaleCli()
+}
+
+// GetLocales retrieves the IETF BCP 47 language tags set on the system.
+func GetLocales() ([]string, error) {
+	return getLocalesCli()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -130,7 +130,7 @@ github.com/hack-pad/go-indexeddb/idb/internal/jscache
 github.com/hack-pad/safejs
 github.com/hack-pad/safejs/internal/catch
 github.com/hack-pad/safejs/internal/stackerr
-# github.com/jeandeaual/go-locale v0.0.0-20241217141322-fcc2cadd6f08
+# github.com/jeandeaual/go-locale v0.0.0-20250421151639-a9d6ed1b3d45
 ## explicit; go 1.18
 github.com/jeandeaual/go-locale
 # github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25


### PR DESCRIPTION
```text
github.com/jeandeaual/go-locale
    from v0.0.0-20241217141322-fcc2cadd6f08
    to   v0.0.0-20250421151639-a9d6ed1b3d45
```

Applied via:

1. `go get -u github.com/jeandeaual/go-locale@latest`
2. `go mod tidy`
3. `go mod vendor`