### PR TITLE
Fix markdownlint MD060/table-column-style error

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ normalize/decode) Microsoft Office 365 "Safe Links" URLs.
 
 | Tool Name | Overall Status | Description                                                               |
 | --------- | -------------- | ------------------------------------------------------------------------- |
-| `usl`     | 🆗Beta          | Small CLI tool for decoding a given Safe Links URL.                       |
-| `dsl`     | 💥Alpha         | Small CLI tool for decoding Safe Links URLs within input text.            |
-| `dslg`    | 💥Alpha         | GUI tool for decoding Safe Links URLs within input text.                  |
-| `eslg`    | 💥Alpha         | GUI tool for encoding normal URLs within input text for testing purposes. |
+| `usl`     | Beta           | Small CLI tool for decoding a given Safe Links URL.                       |
+| `dsl`     | Alpha          | Small CLI tool for decoding Safe Links URLs within input text.            |
+| `dslg`    | Alpha          | GUI tool for decoding Safe Links URLs within input text.                  |
+| `eslg`    | Alpha          | GUI tool for encoding normal URLs within input text for testing purposes. |
 
 ## Features
 


### PR DESCRIPTION
The `Markdown All in One` VSCode extension formatted the project tool status table in a way that violated the linting rules applied by the `markdownlint` tool. We work around this by removing the emoji used as quick reference status indicators.